### PR TITLE
Set support lib to fixed version

### DIFF
--- a/Lib/build.gradle
+++ b/Lib/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile 'com.android.support:support-v4:19.1.0'
 }


### PR DESCRIPTION
Better use a fixed version number. These dynamic version deps have often introduced problems when a lib released a new version with a new issue.
